### PR TITLE
Fix undefined colour in `res.end`

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = function createExpressLogger (log, options) {
     const duration = Date.now() - start
 
     let logLevel
-    let color
+    let color = 'white'
     if (status >= 100) {
       logLevel = 'info'
       color = 'green'


### PR DESCRIPTION
Should fix this: https://sentry.qutics.com/sentry/aperture/issues/3782/